### PR TITLE
Update json requirements to work with a Rails 6 project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk7
 
 rvm:
-  - "2.0.0"
+  - "2.2.3"
 
 # whitelist
 branches:

--- a/mockserver-client-ruby/lib/mockserver-client.rb
+++ b/mockserver-client-ruby/lib/mockserver-client.rb
@@ -2,16 +2,3 @@
 require_relative './mockserver/version'
 require_relative './mockserver/mock_server_client'
 require_relative './mockserver/proxy_client'
-
-# Setup serialization correctly with multi_json
-require 'json/pure'
-
-# To fix serialization bugs. See: http://prettystatemachine.blogspot.com/2010/09/typeerrors-in-tojson-make-me-briefly.html
-class Fixnum
-  def to_json(_)
-    to_s
-  end
-end
-
-require 'multi_json'
-MultiJson.use(:json_pure)

--- a/mockserver-client-ruby/lib/mockserver/model/enum.rb
+++ b/mockserver-client-ruby/lib/mockserver/model/enum.rb
@@ -33,6 +33,14 @@ module MockServer::Model
     def to_s
       @value.to_s
     end
+
+    def as_json(_)
+      @value.to_s
+    end
+
+    def to_json(_)
+      "\"#{@value}\""
+    end
   end
 
   # Subclass of Enum that has a list of symbols as allowed values.

--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -28,10 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23'
 
   spec.add_dependency 'hashie', '~> 3.0'
-  spec.add_dependency 'json', '~> 1.8'
-  spec.add_dependency 'json_pure', '~> 1.8'
-  spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'rest-client', '~> 1.7'
+  spec.add_dependency 'json', '>= 1.8'
+  spec.add_dependency 'activesupport', '>= 4.1'
+  spec.add_dependency 'rest-client', '>= 1.7'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'colorize', '~> 0.7'

--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A Ruby Client for MockServer that enables easy mocking of any system you integrate with via HTTP or HTTPS (i.e. services, web sites, etc)'
 
   spec.required_ruby_version     = '>= 2.0'
-  spec.required_rubygems_version = '~> 2.0'
+  spec.required_rubygems_version = '>= 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }

--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 4.1'
   spec.add_dependency 'rest-client', '>= 1.7'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
-  spec.add_dependency 'thor', '~> 0.19'
+  spec.add_dependency 'thor', '~> 1.0'
   spec.add_dependency 'colorize', '~> 0.7'
 end


### PR DESCRIPTION
- Locking the json to an old version seems uneccessary
- Forcing multi_json and json_pure monkeypatching broke our test suite
- removed the json_pure and so far so good